### PR TITLE
allow to hide scores

### DIFF
--- a/src/python/DAS/utils/das_config.py
+++ b/src/python/DAS/utils/das_config.py
@@ -194,6 +194,7 @@ DASOption('keyword_search', 'kws_on', 'bool', False),
 DASOption('keyword_search', 'kws_service_on', 'bool', False),
 # max time for exhaustive search ranker, default 5 seconds
 DASOption('keyword_search', 'timeout', 'int', 5),
+DASOption('keyword_search', 'show_scores', 'bool', False),
 
 #
 # Load balancing

--- a/src/python/DAS/web/das_kwd_search.py
+++ b/src/python/DAS/web/das_kwd_search.py
@@ -92,7 +92,8 @@ class KeywordSearchHandler(object):
         hi_score_result_types.append('any')
         return hi_score_result_types
 
-    def handle_search(self, webm, query, dbsmngr, is_ajax=False, timeout=5):
+    def handle_search(self, webm, query, dbsmngr, is_ajax=False, timeout=5,
+                      show_score=False):
         """
         performs the search, and renders the search results
         """
@@ -116,4 +117,5 @@ class KeywordSearchHandler(object):
                                  is_ajax=is_ajax,
                                  proposed_queries = proposed_queries,
                                  hi_score_result_types = hi_score_result_types,
-                                 err=err)
+                                 err=err,
+                                 show_score=show_score)

--- a/src/python/DAS/web/das_web_srv.py
+++ b/src/python/DAS/web/das_web_srv.py
@@ -429,13 +429,15 @@ class DASWebService(DASWebManager):
             return 'Query suggestions are unavailable right now...'
 
         timeout = self.dasconfig['keyword_search']['timeout']
+        show_scores = self.dasconfig['keyword_search'].get('show_scores', False)
         dbsmngr = self._get_dbsmgr(inst)
 
         return self.kws.handle_search(self,
                                       query=uinput,
                                       dbsmngr=dbsmngr,
                                       is_ajax=True,
-                                      timeout=timeout)
+                                      timeout=timeout,
+                                      show_score=show_scores)
 
     @expose
     @checkargs(DAS_WEB_INPUTS)

--- a/src/templates/kwdsearch_results.tmpl
+++ b/src/templates/kwdsearch_results.tmpl
@@ -55,9 +55,11 @@
 
                <div class="score-bar" style="width: ${item.bar.max_w}px;">
                          <div class="score-bar-inner score-bar-inner-${item.bar.style}" style="width: ${item.bar.w}px;"></div>
+                         #if $show_score:
                          <span class="score-num">
                                 #echo "%.2f" % $item.bar.score
                          </span>
+                         #end if
                </div>
 
                <a class="kws-link" href="$item.link" target="_blank"


### PR DESCRIPTION
- new (optional) config option in KWS: show_scores. fixes issue #81
- by default scores are hidden
- the colors assignment is still not perfect (maybe we shall show no colors?), but this will come with improvements to scoring...
