### PR TITLE
 fix to  use compiled das_map.pattern in KWS

### DIFF
--- a/src/python/DAS/keywordsearch/metadata/schema_adapter2.py
+++ b/src/python/DAS/keywordsearch/metadata/schema_adapter2.py
@@ -162,14 +162,19 @@ class DasSchemaAdapter(object):
 
         params_list = []
         for p in api_inputs:
-            param_constr = p.get('pattern', '')
             param_def = {
                 'api': api,
                 'system': sys,
                 'key': p['das_key'],
                 'entity_long': p['rec_key'],
-                'constr': param_constr,
+                'constr': '',
+                'regex_compiled': None,
                 'lookup': lookup_key}
+            # the patterns defining the inputs accepted are compiled-regexps
+            if 'pattern' in p:
+                regex = p['pattern']
+                param_def['regex_compiled'] = regex
+                param_def['constr'] = regex.pattern
             params_list.append(param_def)
 
         return api_def, params_list


### PR DESCRIPTION
now KWS uses compiled_regex.pattern

---

_older messages...._
loooking deeper into the code how initdasmapcache implemented it seemed that you expected the apiinfocache to contain unmodified records, while dasmapcache to have modified ones, this is not the case because the das_maps are mutable, and therefore get updated in both dasmapcache and apiinfocache.
see here: https://github.com/dmwm/DAS/commit/997f31f02718bec23ade3bfc6689132fd3902fc2#diff-8235662af7c6da9d4db03775ad31bf65R408
