### PR TITLE
make KWS results more clear to the user

### DIFF
--- a/src/python/DAS/utils/das_config.py
+++ b/src/python/DAS/utils/das_config.py
@@ -201,6 +201,8 @@ DASOption('keyword_search', 'kws_service_on', 'bool', False),
 # max time for exhaustive search ranker, default 5 seconds
 DASOption('keyword_search', 'timeout', 'int', 5),
 DASOption('keyword_search', 'show_scores', 'bool', False),
+DASOption('keyword_search', 'colored_scorebar', 'bool', False),
+
 
 #
 # Load balancing

--- a/src/python/DAS/web/das_kwd_search.py
+++ b/src/python/DAS/web/das_kwd_search.py
@@ -11,6 +11,7 @@ import cgi
 import math
 
 from DAS.keywordsearch.search import KeywordSearch
+from DAS.utils.das_config import das_readconfig
 
 avg = lambda l: len(l) and float(sum(l))/len(l)
 
@@ -23,6 +24,9 @@ class KeywordSearchHandler(object):
         if not dascore:
             raise Exception("dascore needed")
         self.kws = KeywordSearch(dascore)
+        config = das_readconfig()
+        self.colored_scorebar = \
+            config['keyword_search'].get('colored_scorebar', False)
 
     @classmethod
     def _get_link_to_query(cls, query, kw_query=''):
@@ -40,8 +44,7 @@ class KeywordSearchHandler(object):
         das_url = '/das/request?' + urllib.urlencode(params)
         return das_url
 
-    @classmethod
-    def _prepare_score_bar(cls, q):
+    def _prepare_score_bar(self, q):
         """
         prepares the score bar for each query (max_w & w is in pixels)
         """
@@ -53,7 +56,7 @@ class KeywordSearchHandler(object):
                       (score < 0.60) and 'avg' or 'high'
         return {'max_w': max_w,
                 'w': w,
-                'style': color_class,
+                'style': self.colored_scorebar and color_class or 'no-color',
                 'score': q['len_normalized_score']}
 
     @classmethod

--- a/src/templates/kwdsearch_results.tmpl
+++ b/src/templates/kwdsearch_results.tmpl
@@ -37,7 +37,7 @@
 
 <div id="kws-results-container">
     <div id="kws-entry-points">
-        <h4>Color-coding:</h4>
+        <h4>Coloring of query suggestions:</h4>
         <span class="q-res-type">entity to be retrieved</span> <br />
         <span class="q-field-name">filter (an input to service(s))</span> <br />
         <span class="q-post-filter-field-name">expensive filter (applied only after retrieving all data)</span>


### PR DESCRIPTION
- disable multiple colors in KWS results score bars, so it would confuse less the users. fixes #4059 
  -  configurable option, by default no colors displayed
- improved wording in the color legend of kws results (on the right)
