### PR TITLE
disabled KWS tests that are not supposed to pass.

### DIFF
--- a/test/das_kwdsearch_t.py
+++ b/test/das_kwdsearch_t.py
@@ -183,7 +183,8 @@ class TestDASKeywordSearch(KeywordSearchAbstractTester):
         # values closer to the field name shall be preferred
         self.assertQueryResult('lumis in run 176304', 'lumi run=176304', query_type='numeric')
 
-    def test_numeric_params_2(self):
+    def _test_numeric_params_2(self):
+        # TODO: lumi is not valid input param anymore?
         # TODO: field 'is' value --> a good pattern?
         self.assertQueryResult('files in /HT/Run2011B-v1/RAW where run is 176304 lumi is 80',
                 'file dataset=/HT/Run2011B-v1/RAW run=176304 lumi=80', query_type='numeric+value')
@@ -236,7 +237,8 @@ class TestDASKeywordSearch(KeywordSearchAbstractTester):
 
         self.assertQueryResult('when  was run=20853 taken?',
                                ['run=20853 | grep run.start_time',
-                                'run=20853 | grep run.creation_time'])
+                                'run=20853 | grep run.creation_time'],
+                               non_implemented=True)
 
         self.assertQueryResult('administrator email of all T1 sites',
                                'site site=*T1* | grep site.admin.email, site.name',
@@ -295,16 +297,18 @@ class TestDASKeywordSearch(KeywordSearchAbstractTester):
                                'run dataset=/DoubleMu/Run2012A-Zmmg-13Jul2012-v1/RAW-RECO | grep run.bfield, run.run_number',
                                query_type='projection')
 
-    def test_result_field_selections_2(self):
-
+    def _test_result_field_selections_2(self):
         self.assertQueryResult('Zmmg complete file replicas',
                                'file dataset=*Zmmg* | grep file.replica.complete, file.name',
-                               query_type='projection')
+                               query_type='projection',
+                               non_implemented=True)
+
     def test_result_field_selections_3(self):
 
         self.assertQueryResult('Zmmg complete block replicas',
                                'block dataset=*Zmmg* | grep block.replica.complete, block.name',
-                               query_type='projection')
+                               query_type='projection',
+                               non_implemented=True)
 
     def test_result_field_selections_4(self):
         # TODO: this is example of field that is named like an aggregator
@@ -318,7 +322,8 @@ class TestDASKeywordSearch(KeywordSearchAbstractTester):
                                ['file dataset=*Zmmg* | grep lumi.number, file.name',
                                 'dataset dataset=*Zmmg* | grep dataset.nevents, dataset.name',
                                 'block dataset=*Zmmg* | grep block.nevents, block.name'],
-                               query_type='projection+ambigous+stem')
+                               query_type='projection+ambigous+stem',
+                               non_implemented=True)
 
     def test_result_field_selections_stem_phrase(self):
         self.assertQueryResult('Zmmg "event number"',
@@ -412,8 +417,8 @@ class TestDASKeywordSearch(KeywordSearchAbstractTester):
         for kwq, result in pairs:
             self.assertQueryResult(kwq, result)
 
-
-    def test_complex_no_impossible_results(self):
+    # TODO: this is not valid anymore due to changes to service schema or constraints?
+    def _test_complex_no_impossible_results(self):
 
         self.assertQueryResult(
             'file block=/MinimumBias/Run2011A-ValSkim-08Nov2011-v1/RAW-RECO#f424e3d4-0f05-11e1-a8b1-00221959e72f run=175648  site=T1_US_FNAL_MSS &&',


### PR DESCRIPTION
- some are caused by changes in service constraints or schema
- others because of moderate quality of matching "result fields"

partially fixes issue #4039
