### PR TITLE
added cms_query_rewrite.tmpl which was not added into git in earlier commit/pull

### DIFF
--- a/src/templates/cms_query_rewrite.tmpl
+++ b/src/templates/cms_query_rewrite.tmpl
@@ -1,3 +1,6 @@
+### the outputs of this template are clear text which will be 
+### later sanitized (quoted) in the das_error template
+
 DAS (or underlying services) do not support this query yet.
 
 Still you can run multiple queries and combine their results:


### PR DESCRIPTION
it had to go along with commit 74c6963b386496c6e9bc9197ec9f383e7a760599 in https://github.com/dmwm/DAS/pull/4051

the only impact of this template being missing is if user types/clicks on an  "almost valid" DAS query, but fields in greps do not exist the query rewrite suggestion will not show: "Template cms_query_rewrite not known".
