### PR TITLE
show the wildcard query suggestions

### DIFF
--- a/src/python/DAS/core/das_query.py
+++ b/src/python/DAS/core/das_query.py
@@ -60,15 +60,13 @@ class DASQuery(object):
             for match in dataset_matches:
                 options[match] = self.query.replace(val, match)
             raise WildcardMultipleMatchesException(msg + ' ' +
-                    'The query is matching more than one ' +
-                    'such dataset pattern.\n' +
-                    'Please choose one from these:\n', options)
+                    'The query matches these dataset patterns:\n', options)
         else:
             # If there's only one match, still ask for user's confirmation
             match = dataset_matches[0]
             options = {match: self.query.replace(val, match)}
             raise WildcardMultipleMatchesException(msg + ' ' +
-                    'The query is matching only one dataset in our cache, but '
+                    'The query matches one dataset pattern in our cache, but '
                     'please check if this is what you intended:\n', options)
 
     def __init__(self, query, **flags):

--- a/src/python/DAS/web/das_web_srv.py
+++ b/src/python/DAS/web/das_web_srv.py
@@ -530,20 +530,17 @@ class DASWebService(DASWebManager):
                     # standard html mode
                     guide = self.templatepage('dbsql_vs_dasql',
                                 operators=', '.join(das_operators()))
-
                     page = self.templatepage('das_wildcard_err', error=str(err),
                             base=self.base, guide=guide, suggest=suggest)
                 else:
                     # text mode
                     page = self.templatepage('das_wildcard_err_txt',
                                 base=self.base, error=str(err), suggest=suggest)
-
-            # whether to show Keyword Search now
-            show_kws = self.is_kws_enabled() and \
-                       not isinstance(err, WildcardMatchingException)
-
-            das_parser_error(uinput, str(type(err)))
-            page = helper(str(err), html_error, show_kws=show_kws)
+            else:
+                # whether to show Keyword Search now
+                show_kws = self.is_kws_enabled()
+                das_parser_error(uinput, str(type(err)))
+                page = helper(str(err), html_error, show_kws=show_kws)
             return 1, page
 
         fields = dasquery.mongo_query.get('fields', [])

--- a/src/templates/das_wildcard_err.tmpl
+++ b/src/templates/das_wildcard_err.tmpl
@@ -5,10 +5,12 @@
 #assert (isinstance($error, str) or isinstance($error, unicode))
 <!-- das_wildcard_err.tmpl -->
 <div> <!-- main div -->
-Input query contains a wild-card statement which is ambiguous:
+    <div class="das-ambigous">
+    Input query contains a wildcard statement which is ambiguous:<br />
 <pre>
 $error
 </pre>
+    </div>
 #if $suggest
 Suggested queries:
 <ul>

--- a/src/templates/das_wildcard_err_txt.tmpl
+++ b/src/templates/das_wildcard_err_txt.tmpl
@@ -1,14 +1,11 @@
 ## P.S. we need no quoting in text mode...
-
 #assert isinstance($base, str)
 #assert (isinstance($error, str) or isinstance($error, unicode))
-
 Input query contains a wild-card statement which is ambiguous:
 $error
 
 #if $suggest
 Suggested queries:
-
 #for query in $suggest
     $query
 #end for


### PR DESCRIPTION
**Changes:**
- show clickable query suggestions (not only wildcard patterns)
- minor rewrite of "error" messages
- fixed presentation in CLI mode (removed extra spaces)

**Now the results look as following**:
![wildcard_one_match](https://f.cloud.github.com/assets/213426/1574020/c47ddc46-5137-11e3-9545-2bd1d815298e.png)
![wilcard_multiple_matches](https://f.cloud.github.com/assets/213426/1574021/cac1e62e-5137-11e3-83f2-b28c2bffd4b9.png)

from CLI:

```
$ python ~/das_client.py --host=http://localhost:8212 --query="dataset=*Zmm*"
status: fail, reason: Can not interpret the query (while creating DASQuery)

Input query contains a wild-card statement which is ambiguous:
Dataset value requires 3 slashes. The query matches these dataset patterns:
/*/*Zmm*/*
/*Zmm*/*/*

Suggested queries:
    dataset=/*/*Zmm*/*
    dataset=/*Zmm*/*/*

For easier query debuging, please use the DAS web interface first.
```

```
$ python ~/das_client.py --host=http://localhost:8212 --query="dataset=*relvalZmm*"
status: fail, reason: Can not interpret the query (while creating DASQuery)

Input query contains a wild-card statement which is ambiguous:
Dataset value requires 3 slashes. The query matches one dataset pattern in our cache, but please check if this is what you intended:
/relvalZmm*/*/*

Suggested queries:
    dataset=/relvalZmm*/*/*

For easier query debuging, please use the DAS web interface first.
vidma@vidma-laptop:/storage/DAS/DAS_code/DAS$ 

```
