### PR TITLE
fix for qrewrite failing with dataset wildcards (in testbed, needs patching)

### DIFF
--- a/src/python/DAS/web/cms_query_rewrite.py
+++ b/src/python/DAS/web/cms_query_rewrite.py
@@ -93,8 +93,11 @@ class CMSQueryRewrite(object):
             'grep': list(set(filters_first) | set([pk, ])),
         }
         q1 = DASQuery(q1_mongo)
+        
         q2 = q.mongo_query.copy()
-        q2['spec'] = {pk: '<PK>'}
+        # make DASQuery pass dataset wildcard check
+        pk_to_replace = '/a/b/c' if pk == 'dataset.name' else '<PK>'
+        q2['spec'] = {pk: pk_to_replace}
         q2['filters'] = {'grep': list(filters_nested)}
         q2 = DASQuery(q2)
 
@@ -102,6 +105,8 @@ class CMSQueryRewrite(object):
                                    q1_str=self.convert2dasql(q1),
                                    q2_str=self.convert2dasql(q2),
                                    pk=pk,
+                                   # user replaces this with PK from 1st query
+                                   pk_to_replace=pk_to_replace,
                                    cli_docs=self.CLI_LINK)
         return msg
 

--- a/src/templates/cms_query_rewrite.tmpl
+++ b/src/templates/cms_query_rewrite.tmpl
@@ -7,7 +7,7 @@ Still you can run multiple queries and combine their results:
 
 $q1_str
 for each result:
-    $q2_str  (replace <PK> with value of $pk from first query)
+    $q2_str  (replace ${pk_to_replace} with value of $pk from first query)
 
 Combination of the two queries will give the results expected,
 except for aggregations which have to be implemented manually.


### PR DESCRIPTION
_failing query on testbed:_ `dataset dataset=/RelValZmmg*/*/* | grep dataset.nevents` [link](https://cmsweb-testbed.cern.ch/das/request?view=list&limit=10&instance=cms_dbs_prod_global&input=dataset+dataset%3D%2FRelValZmmg*%2F*%2F*+%7C+grep+dataset.nevents)
- qrewrite was creating a DASQuery({spec: dataset.name='<PK>', ...})
  which was not passing wildcard validation (since wildcard check do not need dbsmanager to be passed).
- the simple fix is to pass a valid dataset name instead (e.g. /a/b/c)

P.S. the patch is based directly on 2.3.0 tag.
P.S. query rewrite works fine, when it is not based on dataset PK: `run dataset=/DoubleMu/Run2012A-Zmmg-13Jul2012-v1/RAW-RECO | grep run.run_number, run.bfield`
