### PR TITLE
update create_das_js script

### DIFF
--- a/bin/create_das_js
+++ b/bin/create_das_js
@@ -1,16 +1,47 @@
-#!/bin/sh
+#!/bin/bash
+# build DAS JSON maps out of DAS YML files
+# the dasmaps js files are written to src/python/DAS/services/cms_maps/ into
+# das_maps.js and das_testbed_maps.js
 
 # build DAS JSON maps out of DAS YML files
-cmd="python src/python/DAS/tools/das_drop_maps.py"
-dir="src/python/DAS/services/cms_maps/"
-map_file="$PWD/das_maps.js"
-rm -f $map_file
-export PYTHONPATH=$PYTHONPATH:$PWD/src/python
-for amap in `ls $dir/*.yml`
-do
-    $cmd --uri-map=$amap | grep -v "###" >> $map_file
-    $cmd --notation-map=$amap | grep -v "###" >> $map_file
-    $cmd --presentation-map=$amap | grep -v "###" >> $map_file
-done
+build_das_maps()
+{
+    cmd="python src/python/DAS/tools/das_drop_maps.py"
+    dir="src/python/DAS/services/cms_maps/"
+    tdir=/tmp/dasmaps
+    rm -rf $tdir
+    mkdir -p $tdir
+    cp $dir/*.yml $tdir
+    if [ "$1" == "production" ]; then
+        map_file="$dir/das_maps.js"
+    else
+        # testbed maps, replace with testbed urls
+        for amap in `ls $tdir/*.yml`
+        do
+            /bin/cat $amap | sed "s/cmsweb.cern.ch/cmsweb-testbed.cern.ch/g" > $amap.tmp
+            rm -f $amap
+            mv $amap.tmp $amap
+        done
+        map_file="$dir/das_testbed_maps.js"
+    fi
+    rm -f $map_file
+    export PYTHONPATH=$PYTHONPATH:$PWD/src/python
+    for amap in `ls $tdir/*.yml`
+    do
+        $cmd --uri-map=$amap >> $map_file
+        $cmd --notation-map=$amap >> $map_file
+        $cmd --presentation-map=$amap >> $map_file
+    done
+    /bin/cat $map_file | grep -v "###" > $map_file.tmp
+    rm -f $map_file
+    mv $map_file.tmp $map_file
+    rm -rf $tdir
+    $cmd --get-verification-token-for=$map_file | grep -v "###" >> $map_file
 
-$cmd --get-verification-token-for=$map_file | grep -v "###" >> $map_file
+}
+
+# generate production DAS maps
+build_das_maps "production"
+
+# generate pre-production DAS maps
+build_das_maps "pre-production"


### PR DESCRIPTION
- it now creates two maps one for production and other for testbed
- i.e. same as in das.spec:das_map() but also append the dasmap verification token
