### PR TITLE
support a more loose dataset pattern

### DIFF
--- a/src/python/DAS/utils/regex.py
+++ b/src/python/DAS/utils/regex.py
@@ -134,3 +134,6 @@ NON_AMBIGUOUS_INPUT_PATTERNS = [
         ('release', r'^CMSSW_'),
         ('site', r'^T[0-3]_')]
 ]
+
+# slash followed by not # and not '.root'
+DATASET_PATTERN_RELAXED = re.compile(r'^/[^#]+(?<!\.root)$')

--- a/test/cms_adjust_input_t.py
+++ b/test/cms_adjust_input_t.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+#-*- coding: ISO-8859-1 -*-
+#pylint: disable-msg=C0103, W0703, C0111, W0511
+
+"""
+tests for dataset wildcard processing
+"""
+# system modules
+
+import unittest
+import doctest
+
+# DAS modules
+import DAS.web.cms_adjust_input
+
+
+class TestCMSAdjustInput(unittest.TestCase):
+
+    def test_doctests(self):
+        """
+        runs doctests defined in DAS.web.cms_adjust_input
+        """
+        (n_fails, n_tests) = doctest.testmod(verbose=True,
+                                             m=DAS.web.cms_adjust_input)
+        self.assertEquals(n_fails, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- added dataset pattern like this: /TT_StoreResults_
  - must start with / and must not contain # and shall not end with '.root'
- include cms_adjust_input doctests into the unitests (test dir)
