### PR TITLE
propagate the error when DASQuery parsing fails

### DIFF
--- a/src/python/DAS/core/das_parser.py
+++ b/src/python/DAS/core/das_parser.py
@@ -57,6 +57,7 @@ def ply_parse_query(query, keys, services, pdir='/tmp', verbose=False):
 #    ply_query = dasply.parser.parse(query)
 #    ply_query = spawn(dasply.parser.parse, query)
 #    return ply_query
+    error = None
     for trial in xrange(1, 3):
         try:
             ply_query = dasply.parser.parse(query)
@@ -65,8 +66,9 @@ def ply_parse_query(query, keys, services, pdir='/tmp', verbose=False):
             msg = "Fail to parse query=%s, trial=%s, exception=%s" \
                     % (query, trial, str(exc))
             print dastimestamp('DAS WARNING ') + ' ' + msg
+            error = exc
         time.sleep(trial/10.)
-    return None
+    raise error
 
 
 def ply_output(query, keys, services, pdir='/tmp', verbose=False):


### PR DESCRIPTION
fixes issue #4107 

without this patch, the user would get meaningless error msg "argument of type 'NoneType' is not iterable", caused by unhandled parser error ( [ply2mongo(mongo_query)](https://github.com/dmwm/DAS/blob/68bd90430544b642ae302977081997e6d2200823/src/python/DAS/core/das_ply.py#L478)  expects a dict, but gets `None`).
