### PR TITLE
show hints on dataset matches in other DBS instances

### DIFF
--- a/src/python/DAS/keywordsearch/entity_matchers/value_matching_dataset.py
+++ b/src/python/DAS/keywordsearch/entity_matchers/value_matching_dataset.py
@@ -14,11 +14,13 @@ from DAS.keywordsearch.config import DEBUG
 from DAS.web.dbs_daemon import find_datasets
 
 
-def match_value_dataset(kwd):
+def match_value_dataset(kwd, dbs_inst=None):
     """ return keyword matches to dataset values in dbsmanager """
-    if not hasattr(request, 'dbs_inst'):
-        return None, None
-    dbs_inst = request.dbs_inst
+    # if no specific dbs_inst passed, get the current one from request
+    if not dbs_inst:
+        if not hasattr(request, 'dbs_inst'):
+                return None, None
+        dbs_inst = request.dbs_inst
 
     dataset_score = None
     upd_kwd = kwd

--- a/src/python/DAS/web/dbs_daemon.py
+++ b/src/python/DAS/web/dbs_daemon.py
@@ -322,6 +322,14 @@ def get_global_dbs_inst():
     return dasmapping.dbs_global_instance()
 
 
+def list_dbs_instances():
+    """ list all DBS instances """
+    from DAS.core.das_mapping_db import DASMapping
+    dasconfig = das_readconfig()
+    dasmapping = DASMapping(dasconfig)
+    return dasmapping.dbs_instances()
+
+
 if __name__ == '__main__':
     test_dbs2()
     test_find_static()


### PR DESCRIPTION
- currently this is shown only for 1 keyword input of len>=3, e.g. andrey, zmm
- it automatically redirect to the dataset query only of keyword matche only in the current instance
  - e.g. RelValZMMGammadvmc --> dataset=_RelValZMMGammadvmc_
- otherwise, only a message/hint is shown [and only if parsing error occured], along with KWS results
  - e.g. zmm is in multiple dbs instances and can also be primary_dataset...
- TOOD: make the hints clickable (only for next release...)

fixes issue #4102

screenshots:
![andrey_multi_match](https://f.cloud.github.com/assets/213426/1887537/44c90372-79ff-11e3-832d-2f390976f240.png)
![zmm_ambigous_kws](https://f.cloud.github.com/assets/213426/1887543/64c78dc4-79ff-11e3-92d7-4e50059cd178.png)
