### PR TITLE
fix to correctly identify system special key

### DIFF
--- a/src/python/DAS/core/das_parser.py
+++ b/src/python/DAS/core/das_parser.py
@@ -226,7 +226,7 @@ class QLManager(object):
         # look-up special key condition
         requested_system = query.get('system', None)
         if  requested_system:
-            if  isinstance(requested_system, str):
+            if  isinstance(requested_system, basestring):
                 requested_system = [requested_system]
             return list( set(slist) & set(requested_system) )
         return slist


### PR DESCRIPTION
- fixes issue #4086 . earlier the query interpretation/parsing was failing in service_apis_map()
- this was caused by self.services(query) returning empty list of "available services"
  - it expected str only, but got unicode in query.get('system', None)
  - solution: use basestring instead of str
