### PR TITLE
make das_create_json_maps less environment specific

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
 
 # command to install dependencies
 install: 
-  - export PYCURL_SSL_LIBRARY=openssl # try openssl or gnutls
+  - export PYCURL_SSL_LIBRARY=openssl # one may try: openssl or gnutls
   - pip install --use-mirrors -r requirements_freezed.txt  # install dependencies
   #- pip install --use-mirrors   pylint flake8 # not used yet: coverage
 
@@ -24,8 +24,7 @@ install:
     # install
   - python setup.py install
   - source ./init_env.sh
-  - dasroot=`python -c "import DAS; print '/'.join(DAS.__file__.split('/')[:-1])"`
-  - ( cd "$dasroot" && das_create_json_maps src/python/DAS/services/maps ) # generate DAS maps
+  - das_create_json_maps src/python/DAS/services/maps
   - das_update_database src/python/DAS/services/maps/das_maps_dbs_prod.js # initialize database
 
 # command to run tests

--- a/bin/das_create_json_maps
+++ b/bin/das_create_json_maps
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # find out where DAS is installed on a system
-daspython=`env | grep PYTHONPATH | grep DAS`
-if [ -n "$daspython" ]; then
-    dasroot=`python -c "import DAS; print '/'.join(DAS.__file__.split('/')[:-1])"`
-else
+dasroot=`python -c "import DAS; print '/'.join(DAS.__file__.split('/')[:-1])"`
+if [ -z "$dasroot" ]; then
+    # if DAS is not installed, use current dir
+    echo "Warning: unable to import DAS, using the working directory"
     dasroot=$PWD
 fi
 


### PR DESCRIPTION
- make the bin/das_create_json_maps to correctly identify dasroot
  - try importing DAS to get dasroot, if unsuccessful use $PWD
  - now it will work even when PYTHONPATH is unavailable, e.g. in pip or system-wide installs
- update travis config accordingly

comment: one may introduce a separate (optional) argument for dasroot but this would require changing existing scripts (including das.spec), so I do see no such need for now
