### PR TITLE
detailed instructions on quick installation with pip/virtualenv

### DIFF
--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -1,6 +1,77 @@
 Installation
 ============
 
+Quick installation with pip and virtualenv
+-----------------------------------------
+Basically on a Debian-like system you may just copy&paste all
+the commands below into a bash.
+
+.. code-block:: bash
+
+    # get or install virtualenv, see http://www.virtualenv.org/en/latest/virtualenv.html#installation
+    # easiest is through apt-get or "pip install virtualenv" if available
+    sudo apt-get install python-virtualenv
+
+    # create virtual env
+    virtualenv dasenv # will use dir "dasenv"
+
+    # activate the virtualenv -- has to be run in every new shell
+    source dasenv/bin/activate
+
+    # get DAS source code
+    git clone git://github.com/dmwm/DAS.git
+    cd DAS
+
+    # install dependencies
+    export PYCURL_SSL_LIBRARY=gnutls  # depending on your distro try: openssl or gnutls
+    pip install -r requirements_freezed.txt
+    python -m nltk.downloader -e words stopwords wordnet
+
+    # you also need to connect to or install a MongoDB server, e.g.
+    sudo apt-get install mongodb-server
+    # set MongoDB port to 8230 in /etc/mongodb.conf or change dasconfig
+    # sed -i -e 's/8230/27017/g'  etc/das.cfg
+    # sed -i -e 's/8230/27017/g'  bin/das_db_import
+
+
+    # install DAS
+    python setup.py install
+    source ./init_env.sh
+
+    # initialize database with (default) service mappings
+    das_create_json_maps src/python/DAS/services/maps
+    das_update_database src/python/DAS/services/maps/das_maps_dbs_prod.js
+
+    # download YUI (the location is set in init_env.sh)
+    (curl -o yui.zip -L http://yuilibrary.com/downloads/yui2/yui_2.9.0.zip && \
+     unzip yui.zip && mkdir -p  $YUI_ROOT && cp -R yui/* $YUI_ROOT/ )
+
+    # run the tests
+    source ./init_env.sh
+    touch /tmp/x509up_u$UID  # or use grid-proxy-init if you require certs...
+    python setup.py test
+
+    # finally start das server
+    # P.S. don't forget "source dasenv/bin/activate" when restarting in a new shell
+    source ./init_env.sh
+    bash das_server start
+    # Finally you can access it at: http://localhost:8212/das/
+
+
+If, while running tests or starting DAS, you experience problems like
+"pycurl: libcurl link-time ssl backend (gnutls) is different from
+compile-time ssl backend (openssl)", try reinstalling (pycurl) using
+a different PYCURL_SSL_LIBRARY, e.g.:
+
+.. code-block:: bash
+
+    PYCURL_SSL_LIBRARY=openssl
+    pip uninstall pycurl && pip install -r requirements_freezed.txt
+
+
+For more details continue reading below.
+
+
 Source code
 -----------
 
@@ -59,8 +130,8 @@ and then invoke pip:
     pip install pycurl
 
 
-DAS installation and configuration
-----------------------------------
+DAS installation and configuration (old)
+----------------------------------------
 
 To get DAS release just clone it from GIT repository:
 

--- a/init_env.sh
+++ b/init_env.sh
@@ -7,5 +7,5 @@ export DAS_JSPATH=$DAS_ROOT/web/js
 export DAS_CSSPATH=$DAS_ROOT/web/css
 export DAS_IMAGESPATH=$DAS_ROOT/web/images
 # TODO: YUI is not yet installed automatically
-export YUI_ROOT=$DAS_ROOT/web/js
+export YUI_ROOT=$DAS_ROOT/web/js/yui
 


### PR DESCRIPTION
Instructions for a complete installation with pip/virtualenv, including YUI.

Future improvements:
- [ ] bin/das_db_import to take db host/port from das config file (I'll do)
  - regarding the default MongoDB port, shall we have it in default config (etc/das.cfg) same as in default installation 27017?
- [ ] the older installation instructions below are slightly old/deprecated/messy, shall we remove/change them? (can wait)

P.S. there is 100 ways for virtualenv installation, I'm listing the simplest one, and if it doesn't work users may refer to their manual or see what's available in their distro.
