### PR TITLE
reorganize the docs to make the index smaller and more intuitive

### DIFF
--- a/doc/sphinx/about_das.rst
+++ b/doc/sphinx/about_das.rst
@@ -1,0 +1,25 @@
+.. _das_about
+.. include:: introduction.rst
+
+.. _das_works
+How DAS works?
+==============
+
+.. toctree::
+   :maxdepth: 2
+   
+   workflow
+
+
+.. _das_how
+How to use DAS?
+===============
+
+DAS can be used from web interface, through a command line interface, or accessed programically from other applications.
+
+.. toctree::
+   :maxdepth: 2
+   
+   das_ql
+   das_client
+

--- a/doc/sphinx/benchmark.rst
+++ b/doc/sphinx/benchmark.rst
@@ -1,8 +1,114 @@
-DAS benchmarks
-==============
+DAS performance benchmarks
+==============================
 
-DAS profiling
--------------
+Performance benchmarks
+----------------------------------------
+
+.. rubric:: CMS data used for Benchmarks
+
+We used ~50K datasets from CMS DBS system and ~450K block records
+from both DBS and Phedex CMS systems. All of them were populated
+into DAS cache up-front, since I was only interested in read tests
+(DAS have an ability to populate the cache).
+The tests consist of three different types of queries:
+
+- all clients use fixed value for DAS queries, e.g. dataset=/a/b/c or block=/a/b/c#123
+- all clients use fixed pattern for DAS queries, e.g. dataset=/a* or block=/a*
+- all clients use random patterns, e.g. dataset=/a*, dataset=/Z* or block=/a*, block=/Z*
+
+Once the query has been placed into DAS cache server we retrieve
+only first record out of the result set and ship it back to the client.
+The respond time is measured as the total time DAS server spends for
+a particular query.
+
+.. rubric:: Benchmark results
+
+First, we tested our CherryPy server and verified that it can sustain a
+load of 500 parallel clients at the level of 10^-5 sec. Then we populated
+MongoDB with 50k dataset and 500k block records from DBS and Phedex
+CMS systems. We performed the read test of MongoDB and DAS using
+1-500 parallel clients with current set of CMS datasets and block
+meta-data, 50K and 450K, respectively. Then we populated MongoDB
+with 10x and 100x of statistics and repeat the tests.
+The plot showing below represents comparison of DAS (red lines)
+versus MongoDB (blue lines) read tests for 50k (circles),
+500k (down triangles), 5M (up triangles) and 50M (stars):
+
+.. figure::  _images/das_vs_mongo4blocks.png
+   :align:   center
+
+We found these results very satisfactory. As was expected
+MongoDB can easily sustain such load at the level of few mili-seconds.
+The DAS numbers also seems reasonable since DAS workflow is much
+more complicated. It includes DAS parsing, query analysis, analytics, etc.
+The most important, the DAS performance seems to be driven by
+MongoDB back-end and has constant scale factor which can be tuned later.
+
+Next we performed three tests discussed above with 10x of block meta-data
+statistics.
+
+.. figure::  _images/blocks_lookup.png
+   :align:   center
+
+The curve with circles points represents test #1, i.e. fixed key-value,
+while top/down triangles represents pattern value and random pattern
+value, tests #2 and #3, respectively. As can be seen pattern tests
+are differ by the order of magnitude from fixed key-value,
+but almost identical among each other.
+
+Finally, we tested DAS/MongoDB with random queries and random data access,
+by asking to return me a single record from entire collection (not only
+the first one as shown above). For that purpose we generated a random
+index and used idx/limit for MongoDB queries. Here is the results
+
+.. figure::  _images/das_vs_mongo_fully_random.png
+   :align:   center
+
+The blue line shows MongoDB performance, while red shows the DAS.
+This time the difference between DAS and MongoDB is only one order of
+magnitude differ with respect to first shown plot and driven by DAS workflow.
+
+
+.. rubric:: Benchmarks tool
+
+The DAS provides a benchmarking tool, das_bench
+
+.. doctest::
+
+    das_bench --help
+
+    Usage: das_bench [options]
+
+    Examples:
+      Benchmark Keyword Search:
+      das_bench --url=https://cmsweb-testbed.cern.ch/das/kws_async --nclients=20 --dasquery="/DoubleMu/A/RAW-RECO magnetic field and run number" --output=results.png
+
+      Benchmark DAS Homepage (repeating each request 10 times):
+      src/python/DAS/tools/das_bench.py --url=https://das-test-dbs2.cern.ch/das --nclients=30 --dasquery="whatever" --accept=text/html --logname=DAS --output=DAS_home_no_kws_.png --repeat=10
+
+
+    Options:
+      -h, --help            show this help message and exit
+      -v DEBUG, --verbose=DEBUG
+                            verbose output
+      --url=URL             specify URL to test, e.g.
+                            http://localhost:8211/rest/test
+      --accept=ACCEPT       specify URL Accept header, default application/json
+      --idx-bound=IDX       specify index bound, by default it is 0
+      --logname=LOGNAME     specify log name prefix where results of N client
+                            test will be stored
+      --nclients=NCLIENTS   specify max number of clients
+      --minclients=NCLIENTS specify min number of clients, default 1
+      --repeat=REPEAT       repeat each benchmark multiple times
+      --dasquery=DASQUERY   specify DAS query to test, e.g. dataset
+      --output=FILENAME     specify name of output file for matplotlib output,
+                            default is results.pdf, can also be file.png etc
+
+which can be used to benchmark DAS.
+
+
+Performance of individual components (profiling)
+------------------------------------------------
 
 DAS has been profiled on vocms67:
 
@@ -60,107 +166,3 @@ The largest contributors to execution time are
    576715    3.002    0.000    8.917    0.000 /data/projects/das/slc5_amd64_gcc434/external/py2-pymongo/1.3/lib/python2.6/site-packages/pymongo/database.py:183(_fix_outgoing)
    969267    2.798    0.000   17.809    0.000 /data/projects/das/slc5_amd64_gcc434/external/py2-pymongo/1.3/lib/python2.6/site-packages/pymongo/database.py:170(_fix_incoming)
    ......
-
-Benchmarks tool
----------------
-
-The DAS provides a benchmarking tool, das_bench
-
-.. doctest::
-
-    das_bench --help
-
-    Usage: das_bench [options]
-
-    Examples:
-      Benchmark Keyword Search:
-      das_bench --url=https://cmsweb-testbed.cern.ch/das/kws_async --nclients=20 --dasquery="/DoubleMu/A/RAW-RECO magnetic field and run number" --output=results.png
-
-      Benchmark DAS Homepage (repeating each request 10 times):
-      src/python/DAS/tools/das_bench.py --url=https://das-test-dbs2.cern.ch/das --nclients=30 --dasquery="whatever" --accept=text/html --logname=DAS --output=DAS_home_no_kws_.png --repeat=10
-
-
-    Options:
-      -h, --help            show this help message and exit
-      -v DEBUG, --verbose=DEBUG
-                            verbose output
-      --url=URL             specify URL to test, e.g.
-                            http://localhost:8211/rest/test
-      --accept=ACCEPT       specify URL Accept header, default application/json
-      --idx-bound=IDX       specify index bound, by default it is 0
-      --logname=LOGNAME     specify log name prefix where results of N client
-                            test will be stored
-      --nclients=NCLIENTS   specify max number of clients
-      --minclients=NCLIENTS specify min number of clients, default 1
-      --repeat=REPEAT       repeat each benchmark multiple times
-      --dasquery=DASQUERY   specify DAS query to test, e.g. dataset
-      --output=FILENAME     specify name of output file for matplotlib output,
-                            default is results.pdf, can also be file.png etc
-
-which can be used to benchmark DAS.
-
-Benchmark CMS data
-------------------
-
-We used ~50K datasets from CMS DBS system and ~450K block records 
-from both DBS and Phedex CMS systems. All of them were populated 
-into DAS cache up-front, since I was only interested in read tests 
-(DAS have an ability to populate the cache).
-The tests consist of three different types of queries:
-
-- all clients use fixed value for DAS queries, e.g. dataset=/a/b/c or block=/a/b/c#123
-- all clients use fixed pattern for DAS queries, e.g. dataset=/a* or block=/a*
-- all clients use random patterns, e.g. dataset=/a*, dataset=/Z* or block=/a*, block=/Z*
-
-Once the query has been placed into DAS cache server we retrieve 
-only first record out of the result set and ship it back to the client. 
-The respond time is measured as the total time DAS server spends for 
-a particular query.
-
-Benchmark results
------------------
-
-First, we tested our CherryPy server and verified that it can sustain a 
-load of 500 parallel clients at the level of 10^-5 sec. Then we populated 
-MongoDB with 50k dataset and 500k block records from DBS and Phedex 
-CMS systems. We performed the read test of MongoDB and DAS using 
-1-500 parallel clients with current set of CMS datasets and block
-meta-data, 50K and 450K, respectively. Then we populated MongoDB 
-with 10x and 100x of statistics and repeat the tests. 
-The plot showing below represents comparison of DAS (red lines) 
-versus MongoDB (blue lines) read tests for 50k (circles), 
-500k (down triangles), 5M (up triangles) and 50M (stars):
-
-.. figure::  _images/das_vs_mongo4blocks.png
-   :align:   center
-
-We found these results very satisfactory. As was expected 
-MongoDB can easily sustain such load at the level of few mili-seconds. 
-The DAS numbers also seems reasonable since DAS workflow is much 
-more complicated. It includes DAS parsing, query analysis, analytics, etc.
-The most important, the DAS performance seems to be driven by 
-MongoDB back-end and has constant scale factor which can be tuned later.
-
-Next we performed three tests discussed above with 10x of block meta-data
-statistics.
-
-.. figure::  _images/blocks_lookup.png
-   :align:   center
-
-The curve with circles points represents test #1, i.e. fixed key-value, 
-while top/down triangles represents pattern value and random pattern 
-value, tests #2 and #3, respectively. As can be seen pattern tests 
-are differ by the order of magnitude from fixed key-value, 
-but almost identical among each other.
-
-Finally, we tested DAS/MongoDB with random queries and random data access, 
-by asking to return me a single record from entire collection (not only 
-the first one as shown above). For that purpose we generated a random 
-index and used idx/limit for MongoDB queries. Here is the results
-
-.. figure::  _images/das_vs_mongo_fully_random.png
-   :align:   center
-
-The blue line shows MongoDB performance, while red shows the DAS. 
-This time the difference between DAS and MongoDB is only one order of 
-magnitude differ with respect to first shown plot and driven by DAS workflow.

--- a/doc/sphinx/changelog.rst
+++ b/doc/sphinx/changelog.rst
@@ -1,7 +1,7 @@
-DAS release notes
+Release notes
 =================
 
-Release 1.X.Y series
+Release 2.X.Y series
 --------------------
 This release series is targeted to DAS production stability and quality.
 
@@ -143,6 +143,12 @@ This release series is targeted to DAS production stability and quality.
   - fix run input parameter for all DBS3 APIs
   - Add runsummaries API
 
+
+Older releases
+--------------------
+
+.. rubric:: Release 1.X.Y series
+--------------------
 - 1.12.X
 
   - Fix wildcards to provide more informative messages in text mode
@@ -589,7 +595,7 @@ This release series is targeted to DAS production stability and quality.
     into separate layer. Create abstract representation class and current
     CMS representation. See ticket 1975.
 
-Release 0.9.X series
+.. rubric:: Release 0.9.X series
 --------------------
 
 - 0.9.X
@@ -624,7 +630,7 @@ Release 0.9.X series
     exc_msg, file_location
   - remove extra cherrypy logging, clean-up DAS server logs
 
-Release 0.8.X series
+.. rubric:: Release 0.8.X series
 --------------------
 
 - 0.8.X
@@ -647,7 +653,7 @@ Release 0.8.X series
   - improve autocompletion
   - work on scalability of DAS web server, ticket #1791
 
-Release 0.7.X series
+.. rubric:: Release 0.7.X series
 --------------------
 This release series is targeted to DAS usability. We collected users
 requests in terms of DAS functionality and usability. All changes made
@@ -678,7 +684,7 @@ towards making DAS easy to use for end-users.
   - add create_indexes into das_db module to allow consistenly create/ensure
     indexes in DAS code
 
-Release 0.6.X series
+.. rubric:: Release 0.6.X series
 --------------------
 This release series is targeted towards DAS production version. We switched from
 implicit to explicit data retrieval model; removed DAS cache server and re-design
@@ -786,7 +792,7 @@ DAS web server; add multitasking support.
   - add error_expire to control how long expire records live in cache, fixes #1240
   - fix monitor plugin to handle connection errors
 
-Release 0.5.X series
+.. rubric:: Release 0.5.X series
 --------------------
 This release series is targeted to DAS stability. We redesigned DAS-QL
 parser to be based on PLY framework; re-write DAS analytics; add benchmarking tools;
@@ -1167,7 +1173,7 @@ performed stress tests and code audit DAS servers.
   - remove src/python/ply to avoid overlap with system defaul ply and added
     src/python/parser to keep parsertab.py around
 
-Release 0.4.X series
+.. rubric:: Release 0.4.X series
 --------------------
 The most significant part of this release is new plug-and-play mechanism
 to add new data-services. This is done via data-service map creation. Each
@@ -1327,7 +1333,7 @@ map is represented data-service URI (URL, input parameters, API, etc.).
   - incorporate all necessary changes for plug-and-play
   - modifications for stand-alone mode
 
-Release V03 series
+.. rubric:: Release V03 series
 ------------------
 
 Major change in this release was a separation of DAS cache into 
@@ -1356,7 +1362,7 @@ stores *raw* API results, while das.merge keeps only merged records.
   - separate DAS cache into das.cache and das.merge collections
 
 
-Release V02 series
+.. rubric:: Release V02 series
 ------------------
 
 This release series is based on MongoDB. After a long evaluation of
@@ -1366,7 +1372,7 @@ different technologies, we made a choice in favor of MongoDB.
 - switch to pipes syntax in QL for aggregation function support
 - switch DAS QL to free keyword based syntax
 
-Release V01 series
+.. rubric:: Release V01 series
 ------------------
 
 Evalutaion series. During this release cycle we played with

--- a/doc/sphinx/das_client.rst
+++ b/doc/sphinx/das_client.rst
@@ -1,4 +1,4 @@
-DAS CLI tool
+DAS Command Line Interface (CLI) tool
 ============
 The DAS Command Line Interface (CLI) tool can be downloaded directly from
 DAS server. It is python-based tool and does not require any additional
@@ -106,7 +106,7 @@ also requested:
      'status': 'ok',
      'timestamp': 1379782017.68}
 
-Using DAS CLI tool in other applications
+Using DAS CLI tool from other applications
 ++++++++++++++++++++++++++++++++++++++++
 
 It is possible to plug DAS CLI tool into other python applications. This can be

--- a/doc/sphinx/das_config.rst
+++ b/doc/sphinx/das_config.rst
@@ -1,13 +1,5 @@
-.. _das_config:
-
-DAS configurations
-==================
-
-.. toctree::
-   :maxdepth: 2
-
 DAS configuration file
-----------------------
+======================
 
 DAS configuration consists of a single file, $DAS_ROOT/etc/das.cfg. Its structure is
 shown below:

--- a/doc/sphinx/das_internals.rst
+++ b/doc/sphinx/das_internals.rst
@@ -1,0 +1,18 @@
+DAS architecture and internals
+******************************
+
+This section describes DAS internal modules and datastructures (including records stored in the database).
+
+.. toctree::
+   :maxdepth: 2
+   
+   architecture.rst
+   das_server.rst
+   das_records.rst
+   analytics.rst
+   das_cache.rst
+   das_merge.rst
+   das_logging.rst
+   das_analytics.rst
+   code.rst
+   benchmark.rst

--- a/doc/sphinx/das_ql.rst
+++ b/doc/sphinx/das_ql.rst
@@ -46,3 +46,25 @@ file and dataset keys and file.size, dataset.name key attributes:
     file dataset=/a/b/c | grep file.size>1 | sum(file.size)
     file dataset=/a/b*
 
+
+Special keywords
+----------------
+DAS has a several special keywords: *system, date, instance, records*.
+
+- The *system* keyword is used to retrieve a records only from specified
+  system (data-service), e.g. DBS.
+- The *date* can be used in different queries and accepts values in
+  YYYYMMDD format as well as can be specified as *last* value, e.g.
+  *date last 24h, date last 60m*, where h, m are
+  hours, minutes, respectively.
+- The *records* keyword can be used to retrieve DAS records regardless
+  from their content. For instance, if one user place a query
+  *site=T1_CH_CERN\**, the DAS requests data from several data-services
+  (Phedex, SiteDB), while the output results will only show site
+  related records. If user wants to see which other records exists
+  in DAS cache for given parameter, he/she can use
+  *records site=T1_CH_CERN\** to do that. In that case user will get back
+  all records (site, block records) associated with given condition.
+
+
+.. include:: das_queries.rst

--- a/doc/sphinx/das_queries.rst
+++ b/doc/sphinx/das_queries.rst
@@ -1,5 +1,5 @@
-CMS DAS queries
-===============
+Sample queries used at CMS
+--------------------------
 Here we provide concrete examples of DAS queries used in CMS.
 
 Find primary dataset
@@ -90,23 +90,3 @@ Jobsummary information
    jobsummary date last 24h
    jobsummary site=T1_DE_KIT date last 24h
    jobsummary user=ValentinKuznetsov
-
-Special keywords
-++++++++++++++++
-DAS has a several special keywords: *system, date, instance, records*.
-
-- The *system* keyword is used to retrieve a records only from specified 
-  system (data-service), e.g. DBS.
-- The *date* can be used in different queries and accepts values in 
-  YYYYMMDD format as well as can be specified as *last* value, e.g. 
-  *date last 24h, date last 60m*, where h, m are 
-  hours, minutes, respectively. 
-- The *records* keyword can be used to retrieve DAS records regardless
-  from their content. For instance, if one user place a query 
-  *site=T1_CH_CERN\**, the DAS requests data from several data-services 
-  (Phedex, SiteDB), while the output results will only show site 
-  related records. If user wants to see which other records exists 
-  in DAS cache for given parameter, he/she can use 
-  *records site=T1_CH_CERN\** to do that. In that case user will get back
-  all records (site, block records) associated with given condition.
-

--- a/doc/sphinx/das_setup.rst
+++ b/doc/sphinx/das_setup.rst
@@ -1,0 +1,18 @@
+Setting up and customizing DAS installation
+*********************************************
+
+First set basic configuration on database to use and other server parameters.
+
+To integrate DAS with your own custom services the biggest and most time
+consuming task is preparing the service mappings which define the services
+to be integrated.
+
+.. toctree::
+   :maxdepth: 2
+   
+   das_config.rst   
+   The service mappings <mapping>
+   new_service.rst
+
+   cms_operations.rst
+   das_operations.rst

--- a/doc/sphinx/dependencies.rst
+++ b/doc/sphinx/dependencies.rst
@@ -1,5 +1,5 @@
 Dependencies
-============
+------------
 DAS is written in python and relies on standard python modules.
 The design back-end is `MongoDB <http://www.mongodb.org>`_,
 which provides *schema-less* storage and a generic query language.

--- a/doc/sphinx/index.rst
+++ b/doc/sphinx/index.rst
@@ -3,8 +3,8 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Data Aggregation System
-=======================
+Data Aggregation System (DAS) for Virtual Data Service Integration
+==================================================================
 
 * **Version**: |version|
 * **Last modified**: |today|
@@ -14,31 +14,13 @@ Contents:
 
 .. toctree::
    :maxdepth: 2
-
-   introduction.rst
-   installation.rst
-   das_ql.rst
-   das_queries.rst
-   das_client.rst
-   architecture.rst
-   workflow.rst
-   das_server.rst
-   das_records.rst
-   mapping.rst
-   analytics.rst
-   das_cache.rst
-   das_merge.rst
-   das_logging.rst
-   das_analytics.rst
-   code.rst
-   new_service.rst
-   das_config.rst
-   cms_operations.rst
-   das_operations.rst
-   benchmark.rst
-   dependencies.rst
-   changelog.rst
-   references.rst
+   
+   about_das
+   installation
+   das_setup
+   das_internals
+   changelog
+   references
 
 Indices and tables
 ------------------

--- a/doc/sphinx/installation.rst
+++ b/doc/sphinx/installation.rst
@@ -72,65 +72,7 @@ a different PYCURL_SSL_LIBRARY, e.g.:
 For more details continue reading below.
 
 
-Source code
------------
-
-DAS source code is freely available from [DAS]_ github repository. To install
-it on your system you need to use `git` which can be found from [GIT]_ web
-site.
-
-Prerequisites
--------------
-DAS depends on the following software:
-
-- MongoDB and pymongo module
-- libcurl library
-- YUI library (Yahoo UI)
-- python modules:
-
-  - yajl (Yet Another JSON library) or cjson (C-JSON module)
-  - CherryPy
-  - Cheetah
-  - PLY
-  - PyYAML
-  - pycurl
-
-To install MongoDB visit their web site [Mongodb]_, download latest binary tar ball,
-unpack it and make its bin directory available in your path.
-
-To install libcurl library visit its web site [CURL]_ and install it on your
-system.
-
-To install YUI library, visit Yahoo developer web site [YUI]_ and install
-version 2 of their yui library.
-
-To install python dependencies it is easier to use standard python installer
-*pip*. In on your to get it download virtual environment [VENV]_
-and run it as following:
-
-.. doctest::
-
-    curl -O https://raw.github.com/pypa/virtualenv/master/virtualenv.py
-    python virtualenv.py <install_dir>
-
-Once it is installed you need to setup your path to point to *install_dir/bin*
-and then invoke pip:
-
-.. doctest::
-
-    export PATH=<install_dir>/bin:$PATH
-    pip install python-cjson
-    pip install czjson
-    pip install CherryPy
-    pip install Cheetah
-    pip install PyYAML
-    pip install yajl
-    pip install pymongo
-    pip install ply
-    pip install pycurl
-
-
-DAS installation and configuration (old)
+DAS installation (old)
 ----------------------------------------
 
 To get DAS release just clone it from GIT repository:
@@ -167,3 +109,41 @@ environment, its context should be something like:
 
 where I installed all packages under local $dir/install area and keep DAS under
 $dir/soft/DAS.
+
+
+.. rubric:: Source code
+
+DAS source code is freely available from [DAS]_ github repository. To install
+it on your system you need to use `git` which can be found from [GIT]_ web
+site.
+
+.. rubric:: Prerequisites
+
+DAS depends on the following software:
+
+- MongoDB and pymongo module
+- libcurl library
+- YUI library (Yahoo UI)
+- python modules:
+
+  - yajl (Yet Another JSON library) or cjson (C-JSON module)
+  - CherryPy
+  - Cheetah
+  - PLY
+  - PyYAML
+  - pycurl
+
+To install MongoDB visit their web site [Mongodb]_, download latest binary tar ball,
+unpack it and make its bin directory available in your path.
+
+To install libcurl library visit its web site [CURL]_ and install it on your
+system.
+
+To install YUI library, visit Yahoo developer web site [YUI]_ and install
+version 2 of their yui library.
+
+To install python dependencies it is easier to use standard python installer
+*pip* (see above).
+
+
+.. include:: dependencies.rst

--- a/doc/sphinx/introduction.rst
+++ b/doc/sphinx/introduction.rst
@@ -1,12 +1,13 @@
 Introduction
 ============
 
-DAS stands for *Data Aggregation System*. It provides a
-a common layer above various data services, to allow end users
+DAS is an opensource virtual data service integration platform.
+The acronym DAS stands for *Data Aggregation System*. It provides a
+a common layer above various data services, allowing end users
 to query one (or more) of them with a more natural, 
-search-engine-like interface. It is developed for the [CMS]_
+search-engine-like interface. It is being developed for the [CMS]_
 High Energy Physics experiment on the [LHC]_, at CERN,
-Geneva, Switzerland. Although it is currently only used for
+Geneva, Switzerland. Although it is currently only used at
 the CMS experiment, it was designed to have a general-purpose
 architecture which would be applicable to other domains.
 

--- a/doc/sphinx/workflow.rst
+++ b/doc/sphinx/workflow.rst
@@ -1,7 +1,7 @@
 .. _das_requestflow:
 
-DAS request flow
-================
+Resolving queries over data services
+====================================
 This diagram illustrates the request flow triggered by a user query.
 
 .. figure:: _images/das_requestflow.png 
@@ -22,8 +22,8 @@ according to the *notation* map for each of those services.
 
 .. _das_workflow:
 
-DAS workflow
-============
+Query processing steps
+======================
 DAS workflow consists of the following steps:
 
 - parse input query


### PR DESCRIPTION
- reorganize (simplify) the index
- join related pages, reorder in some places
- remove unimportant rubrics from main index
- minor language fixes

built docs available in http://das.readthedocs.org/en/docs_reorganize/
