### PR TITLE
fix wildcards

### DIFF
--- a/src/python/DAS/core/das_process_dataset_wildcards.py
+++ b/src/python/DAS/core/das_process_dataset_wildcards.py
@@ -165,6 +165,10 @@ def process_dataset_wildcards(pattern, dbs_inst):
 
     (giving [], instead of: [u'/RelValPyquen_ZeemumuJets_pt10_2760GeV/*/*'])
 
+    >>> process_dataset_wildcards('/ZMM/*', dbs_inst)
+    [u'/ZMM/Summer11-DESIGN42_V11_428_SLHC1-v1/GEN-SIM']
+
+
 
     TODO: Other tests, e.g.
     */4C_TuneZ2_7TeV-alpgen-pythia6/Summer11-PU_S4_START42_V11-v1/AODSIM*

--- a/src/python/DAS/utils/regex.py
+++ b/src/python/DAS/utils/regex.py
@@ -121,7 +121,7 @@ PAT_TIERS = \
 
 # slashes handling in dataset Wildcard queries
 # allowed characters: letters, numbers, dashes and obviously  *
-DATASET_FORBIDDEN_SYMBOLS = re.compile(r'[^a-zA-Z0-9_\-*]*')
+DATASET_FORBIDDEN_SYMBOLS = re.compile(r'[^a-zA-Z0-9_\-*/]*')
 
 
 # rules for rewriting little ambiguous input into DASQL


### PR DESCRIPTION
- the slash '/' was being filtered out from dataset  pattern in wildcard matching
- test: dataset=/ZMM/\* shall result in some suggestions, but it was returning none
