### PR TITLE
fix config for dev setup

### DIFF
--- a/etc/das.cfg
+++ b/etc/das.cfg
@@ -6,7 +6,6 @@ host = 0.0.0.0
 log_screen = True
 url_base = /das
 port = 8212
-kws_port = 8214
 pid = /tmp/logs/das_web_server.pid
 status_update = 2500
 web_workers = 50
@@ -89,6 +88,11 @@ kws_service_on = True
 # if occured it will return whatever was possible to find before
 # this have to be set for the kws backend server only
 timeout=7
+
+[load_balance]
+# in dev setup, KWS and DAS run on different ports, thus valid_origin is needed
+kws_host = http://localhost:8214
+valid_origins = http://localhost:8212,
 
 [query_rewrite]
 pk_rewrite_on = True


### PR DESCRIPTION
- kws_port was present twice
- valid_origins and kws_host are needed in dev setup
  - because we do not run a proxy, its same host but different ports, that are accessed thru ajax
