### PR TITLE
fix hints box not to show up if there are no hints

### DIFF
--- a/src/python/DAS/web/das_web_srv.py
+++ b/src/python/DAS/web/das_web_srv.py
@@ -1114,13 +1114,15 @@ class DASWebService(DASWebManager):
         hint_functions = [hint_dataset_case_insensitive,
                           hint_dataset_in_other_insts, ]
         hints = (hint(query, dbsinst)
-                   for hint in hint_functions)
-        hints = (r for r in hints
-                   if r and r.get('results'))
+                 for hint in hint_functions)
+
+        # select only non-empty hints
+        # p.s. need a list to be able to check if we have any results
+        hints = [r for r in hints
+                 if r and r.get('results')]
 
         # print out the results if debugging
         if self.dasconfig.get('verbose'):
-            hints = list(hints)
             pprint.pprint(hints)
 
         # TODO: base could be a global param passed by templatepage


### PR DESCRIPTION
fixes tiny bug in PR #4154 , so the empty hints box would not be shown, if there are no results.

from:
![from](https://f.cloud.github.com/assets/213426/2234419/ff2bbf62-9b37-11e3-925b-1af4e58347bd.png)

to:
![into](https://f.cloud.github.com/assets/213426/2234421/05addde8-9b38-11e3-8399-8f32398e67cc.png)
