### PR TITLE
preserve query params in KWS,wildcard suggestions,hints; minor bugfix in urlutils

### DIFF
--- a/src/python/DAS/web/das_kwd_search.py
+++ b/src/python/DAS/web/das_kwd_search.py
@@ -12,6 +12,7 @@ import math
 
 from DAS.keywordsearch.search import KeywordSearch
 from DAS.utils.das_config import das_readconfig
+from DAS.utils.url_utils import url_extend_params
 
 avg = lambda l: len(l) and float(sum(l))/len(l)
 
@@ -34,15 +35,9 @@ class KeywordSearchHandler(object):
         returns a link to given query taking into account other parameters
         already present in cherry.request (e.g. instance, page size, etc)
         """
-        params = cherrypy.request.params.copy()
-        params['input'] = query
-
-        # will see in logs which suggestion was selected by user for kw_query
-        if kw_query:
-            params['kwquery'] = kw_query
-
-        das_url = '/das/request?' + urllib.urlencode(params)
-        return das_url
+        return url_extend_params(url='/das/request',
+                                 input=query,
+                                 kwquery=kw_query)
 
     def _prepare_score_bar(self, q):
         """

--- a/src/templates/das_wildcard_err.tmpl
+++ b/src/templates/das_wildcard_err.tmpl
@@ -1,8 +1,9 @@
 #from DAS.web.utils import quote
-#set base = $quote($base)
+#from DAS.utils.url_utils import url_extend_params
 #set msg = $quote($msg)
 #assert isinstance($base, str)
 #assert (isinstance($msg, str) or isinstance($msg, unicode))
+
 <!-- das_wildcard_err.tmpl -->
 <div> <!-- main div -->
     <div class="das-ambigous">
@@ -15,8 +16,10 @@ $msg
 Suggested queries:
 <ul>
 #for query in $suggest
-#set query=$quote($query)
-<li><a href="$base/request?input=$query">$query</a></li>
+  #set query=$quote($query)
+  ## url_extend_params returns a link with urlencoded params
+  #set link=url_extend_params(url=$base + '/request', input=query)
+  <li><a href="$link">$query</a></li>
 #end for
 </ul>
 #end if

--- a/src/templates/hint.tmpl
+++ b/src/templates/hint.tmpl
@@ -1,4 +1,6 @@
 #from DAS.web.utils import quote
+#from DAS.utils.url_utils import url_extend_params
+
 #set title=$quote($hint.title)
 
 <div class="hint-block">
@@ -9,8 +11,9 @@
     #end if
     <ul class="result">
     #for result in $hint.results
-        #set query=$quote($result.query)
-        <li><a href="$base/request?input=$query">$result.match</a>
+        #set query = $quote($result.query)
+        #set link = url_extend_params(url=$base +'/request', input=$query)
+        <li><a href="$link">$result.match</a>
         #if 'examples' in result and $result.examples
             <ul class="examples">
             #for example in $result.examples

--- a/src/templates/hints_via_ajax.tmpl
+++ b/src/templates/hints_via_ajax.tmpl
@@ -1,10 +1,7 @@
 #from json import dumps as jsonize
-#assert isinstance($uinput, basestring)
-#assert isinstance($inst, basestring)
-#assert isinstance($kws_host, basestring)
+#from DAS.utils.url_utils import url_extend_params_as_dict
 
-#set $js_uinput = $jsonize($uinput)
-#set $js_inst = $jsonize($inst)
+#assert isinstance($kws_host, basestring)
 #set $js_kws_host = $jsonize($kws_host)
 
 <div id="cms-hints-container">
@@ -13,20 +10,20 @@
     <br /><br />
 </div>
 
+## this will pass all the default params including user's input
+#set hints_params_json = jsonize(url_extend_params_as_dict())
+
 <script type="text/javascript">
 var KWS_HOST = $js_kws_host; //e.g. "https://localhost"
 new Ajax.Request(KWS_HOST + "/das/hints", {
     method: "get",
-    parameters: {
-        query: $js_uinput,
-        instance: $js_inst
-    },
+    parameters: $hints_params_json,
   onSuccess: function(transport) {
       \$("cms-hints-container").update(transport.responseText);
     initialize_kws_results.defer();
   },
   onFailure: function(err) {
-        \$("cms-hints-container").update("");
+      \$("cms-hints-container").update("");
   }
 });
 </script>

--- a/src/templates/kwdsearch_via_ajax.tmpl
+++ b/src/templates/kwdsearch_via_ajax.tmpl
@@ -1,10 +1,7 @@
 #from json import dumps as jsonize
-#assert isinstance($uinput, basestring)
-#assert isinstance($inst, basestring)
-#assert isinstance($kws_host, basestring)
+#from DAS.utils.url_utils import url_extend_params_as_dict
 
-#set $js_uinput = $jsonize($uinput)
-#set $js_inst = $jsonize($inst)
+#assert isinstance($uinput, basestring)
 #set $js_kws_host = $jsonize($kws_host)
 
 <link rel="stylesheet" href="/das/css/?f=opentip.css&f=kwsearch.css" />
@@ -16,23 +13,22 @@
     <br /><br />
 </div>
 
+## this will pass all the default params including user's input
+## instance is a mandatory KWS param, so it doesn't have to worry about defaults
+#set kws_params_json = jsonize(url_extend_params_as_dict(instance=$inst))
 <script type="text/javascript">
 // TODO: it must a setting
 var KWS_HOST = $js_kws_host; //e.g. "https://localhost"
-
 new Ajax.Request(KWS_HOST + "/das/kws_async", {
     method: "get",
-    parameters: {
-        input: $js_uinput,
-        instance: $js_inst
-    },
-  onSuccess: function(transport) {
+    parameters: $kws_params_json,
+    onSuccess: function(transport) {
       \$("kws-suggestions").update(transport.responseText);
     initialize_kws_results.defer();
-  },
-  onFailure: function(err) {
+    },
+    onFailure: function(err) {
         \$("kws-suggestions").update("can not to load " +
                 "the suggestions at the moment...")
-  }
+    }
 });
 </script>


### PR DESCRIPTION
**this is a non urgent bug fix**, which adds a helper allowing to easily preserve the common params (e.g. instance, limit, view) between the requests (links).
- add a helper function to build links which would preserve the current url parameters (e.g. view, instance, input, limit)
- preserve the selected parameters in:
  - wildcard suggestion links
  - keyword search query result links
  - hint links
- cleanup how hints plugin is added
  - now there's no need to pass the user input arguments, they are taken from request
- off main topic, fix a little bug: accessing undefined variable in urlutils see https://github.com/dmwm/DAS/compare/preserve_url_params?expand=1#diff-0bef3e702565b82309f127d5c9b6f5faR99
