### PR TITLE
do not hardcode mongodb uri in scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
 
   # a hack to use default MongoDB port, which is available in travis
   - sed -i -e 's/8230/27017/g'  etc/das.cfg
-  - sed -i -e 's/8230/27017/g'  bin/das_db_import
+  #- sed -i -e 's/8230/27017/g'  bin/das_db_import
   - rm test/dbs3_t.py   # temp disable dbs3_t as it prevents imports
 
   # install

--- a/bin/das_bootstrap_kws
+++ b/bin/das_bootstrap_kws
@@ -2,6 +2,7 @@
 
 DAS_PYTHONPATH=`python -c "import os, DAS; print os.path.dirname(DAS.__file__)"`
 QUERIES_FILE="$DAS_PYTHONPATH/services/bootstrap_queries/cms_bootstrap_queries_1r.txt"
+. das_read_config # exports DAS_MONGO_PORT, DAS_MONGO_HOST
 
 
 # check number of input arguments
@@ -10,8 +11,8 @@ helpmsg="  This script bootstraps external data needed for keyword search"
 E_BADARGS=65
 if [ $# -eq 1 ]; then
     if  [ "$1" == "-h" ] || [ "$1" == "-help" ] || [ "$1" == "--help" ]; then
-        echo $usage
-        echo $helpmsg
+        echo "$usage"
+        echo "$helpmsg"
         exit
     fi
 fi
@@ -19,7 +20,7 @@ fi
 
 # make sure mongodb is alive (otherwhile das_cli wont start...)
 echo "Waiting for DB"
-python $DAS_PYTHONPATH/tools/das_waitfordb.py
+python ${DAS_PYTHONPATH}/tools/das_waitfordb.py
 if [ $? -ne 0 ]; then
     echo "DB is down for too long. Can not continue"
     exit 1
@@ -47,11 +48,8 @@ fi
 # Clean up only if requested
 if [ $# -eq 1 ]; then
    if  [ "$1" == "--wipe-all" ]; then
-        # TODO: keylearning is not used anywhere now, but is it OK in future?
-        mongo --port 8230 keylearning --eval "db.db.remove(); db.db.find();"
-
-        # TODO: do not wipe cache & merge cols. currently keylearning uses only first few records...
-        mongo --port 8230 das --eval "db.cache.remove(); db.merge.remove();"
+        mongo --host "$DAS_MONGO_HOST" --port "$DAS_MONGO_PORT" keylearning --eval "db.db.remove(); db.db.find();"
+        mongo --host "$DAS_MONGO_HOST" --port "$DAS_MONGO_PORT" das --eval "db.cache.remove(); db.merge.remove();"
     fi
 fi
 
@@ -63,10 +61,10 @@ while read query; do
     das_cli --no-output -q "$query"
 
     # while the results are still in raw cache, update the registry about service result structure
-    python -u  $DAS_PYTHONPATH/analytics/standalone_task.py -c key_learning
+    python -u  ${DAS_PYTHONPATH}/analytics/standalone_task.py -c key_learning
 
-done < $QUERIES_FILE
+done < ${QUERIES_FILE}
 
 # Bootstrap values (release, datatype, etc)
 # TODO: shall this be part of (KWS) webserver?
-python $DAS_PYTHONPATH/keywordsearch/metadata/input_values_tracker.py
+python ${DAS_PYTHONPATH}/keywordsearch/metadata/input_values_tracker.py

--- a/bin/das_create_config
+++ b/bin/das_create_config
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Creates a default config file
 
 # find out where DAS is installed on a system
 dasroot=`python -c "import DAS; print '/'.join(DAS.__file__.split('/')[:-1])"`

--- a/bin/das_db_import
+++ b/bin/das_db_import
@@ -15,7 +15,7 @@ METADATA_DIR=${3:-"$DASROOT/kws_data/db_dumps"}
 JSON_VALIDATOR_DIR="$DASROOT/tools/schema_validators"
 KEYLEARNING_FILE="$METADATA_DIR/update_keylearning_db.js"
 INPUTVAL_FILES="$METADATA_DIR/update_inputvals*.js"
-
+. das_read_config # exports DAS_MONGO_PORT, DAS_MONGO_HOST
 
 # figure out which md5sum utility exists
 MD5CMD=$(for cmd in md5 md5sum; do type $cmd >/dev/null 2>&1 && echo $cmd && break; done);
@@ -45,14 +45,14 @@ update_db()
     # still we have to check if clean script exists, in case of multiple collections...
     if [ -f ${STAGEDIR}/clean_${obj}.js ]; then
         echo "Clean ${obj}"
-        mongo --port 8230 ${STAGEDIR}/clean_${obj}.js
+        mongo --host "$DAS_MONGO_HOST" --port "$DAS_MONGO_PORT" ${STAGEDIR}/clean_${obj}.js
     fi
 
     for entry in ${updates[@]}
     do
         db=$(echo ${entry} | cut -f1 -d_) coll=$(echo ${entry} | cut -f2- -d_)
         echo "Updating db: ${db} col: ${coll}"
-        mongoimport --port 8230 --db ${db} --collection ${coll} --file ${STAGEDIR}/update_${entry}.js
+        mongoimport --host "$DAS_MONGO_HOST" --port "$DAS_MONGO_PORT" --db ${db} --collection ${coll} --file ${STAGEDIR}/update_${entry}.js
     done
     # TODO: what if some file is missing?!
     echo "$stamp" > ${STAGEDIR}/${obj}-schema-stamp

--- a/bin/das_kws_export_data
+++ b/bin/das_kws_export_data
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 DAS_PYTHONPATH=`python -c "import os, DAS; print os.path.dirname(DAS.__file__)"`
+. das_read_config # exports DAS_MONGO_PORT, DAS_MONGO_HOST
 
 # check number of input arguments
 usage="Usage: `basename $0` out_dir"
@@ -8,20 +9,19 @@ helpmsg="  This script exports the external data needed for keyword search"
 E_BADARGS=65
 if [ $# -eq 1 ]; then
     if  [ "$1" == "-h" ] || [ "$1" == "-help" ] || [ "$1" == "--help" ]; then
-        echo $usage
-        echo $helpmsg
+        echo "$usage"
+        echo "$helpmsg"
         exit
     fi
 fi
 
 OUT_DIR=$1
+mkdir -p ${OUT_DIR}/db_dumps/
 
-mkdir -p $OUT_DIR/db_dumps/
-
-mongoexport --port 8230 --db keylearning --collection db --out $OUT_DIR/db_dumps/update_keylearning_db.js
+mongoexport --host "$DAS_MONGO_HOST" --port "$DAS_MONGO_PORT" --db keylearning --collection db --out "${OUT_DIR}/db_dumps/update_keylearning_db.js"
 
 # dump keylearning col and cols for input values (release, datatype, etc)
 for col in  datatype_name group_name primary_dataset_name release_name site_name status_name tier_name
 do
-    mongoexport --port 8230 --db inputvals --collection $col --out $OUT_DIR/db_dumps/update_inputvals_$col.js
+    mongoexport --host "$DAS_MONGO_HOST" --port "$DAS_MONGO_PORT" --db inputvals --collection "${col}" --out "${OUT_DIR}/db_dumps/update_inputvals_${col}.js"
 done

--- a/bin/das_read_config
+++ b/bin/das_read_config
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Read settings from DAS config file to be used in scripts
+
+# find out where DAS is installed on a system
+dasroot=`python -c "import DAS; print '/'.join(DAS.__file__.split('/')[:-1])"`
+# run actual script
+# python $dasroot/tools/config_reader.py "$@"
+export DAS_MONGO_PORT=`python $dasroot/tools/config_reader.py --mongo_port`
+export DAS_MONGO_HOST=`python $dasroot/tools/config_reader.py --mongo_host`

--- a/src/python/DAS/tools/config_reader.py
+++ b/src/python/DAS/tools/config_reader.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+#-*- coding: ISO-8859-1 -*-
+
+import getopt
+import sys
+from pymongo.uri_parser import parse_uri
+from DAS.utils.das_config import das_readconfig
+
+
+def get_mongo_uri():
+    """ read dasconfig and return mongodb host and port (as dict) """
+    uri = das_readconfig()['mongodb']['dburi'][0]
+    parsed_uri = parse_uri(uri)
+    host, port = parsed_uri['nodelist'][0]
+    return dict(mongo_host=host, mongo_port=port)
+
+
+if __name__ == '__main__':
+    OPTS = ['mongo_host', 'mongo_port']
+    try:
+        optlist, _ = getopt.getopt(sys.argv[1:], '', OPTS)
+    except getopt.GetoptError, err:
+        print str(err)
+        exit(1)
+    else:
+        opts = [opt_name for opt_name, _ in optlist]
+        if '--mongo_host' in opts:
+            print get_mongo_uri()['mongo_host']
+        elif '--mongo_port' in opts:
+            print get_mongo_uri()['mongo_port']

--- a/src/python/DAS/web/dbs_daemon.py
+++ b/src/python/DAS/web/dbs_daemon.py
@@ -254,8 +254,8 @@ def find_datasets(pattern, dbs_instance, dbname='dbs', idx=0, limit=10,
 
 def test(dbs_url):
     "Test function"
-    uri = 'mongodb://localhost:8230'
-    config = {'preserve_on_restart':True}
+    uri = das_readconfig()['mongodb']['dburi'][0]
+    config = {'preserve_on_restart': True}
     mgr = DBSDaemon(dbs_url, uri, config)
     mgr.update()
     idx = 0


### PR DESCRIPTION
waiting for your comments...
- retrieve the mongodb uri from das config (also in scripts)
- renamed bin/das_config -> bin/das_create_config (as it didn't make sense)
  - is this still used?
- minor cleanup of scripts (simple variable usage)
